### PR TITLE
Fix warning when form has no emails to notify

### DIFF
--- a/Submission.php
+++ b/Submission.php
@@ -62,8 +62,10 @@ class Submission
         }
 
         // Send notifications
-        foreach ($notify as $email) {
-            $this->notify($email['email'], $_POST['modularity-form-id'], $submission, $from);
+        if ($notify) {
+            foreach ($notify as $email) {
+                $this->notify($email['email'], $_POST['modularity-form-id'], $submission, $from);
+            }
         }
 
         // Send user copy


### PR DESCRIPTION
This fixes an error where forms can't be submitted if notify emails are not provided.

In the form it almost looks like this field is required, but that is not enforced - and I don't think it should be required.