### PR TITLE
Clean up the input templates

### DIFF
--- a/source/php/Module/views/fields-editable/input.blade.php
+++ b/source/php/Module/views/fields-editable/input.blade.php
@@ -1,13 +1,30 @@
-{{-- Input field --}}
 <div class="mod-form-field">
-    <p><b><label for="{{ $module_id }}-input-{{ $field['name'] }}">
-                {{ $field['label'] }}{!! $field['required'] ? '<span class="text-danger">*</span>' : '' !!}
-            </label></b></p>
-    @if (in_array($field['value_type'], array('number', 'range')))
-        <input type="{{ $field['value_type'] }}" id="{{ $module_id }}-input-{{ $field['name'] }}" class="large-text" name="mod-form[{{ $field['name'] }}]" {{  $field['required'] ? 'required' : '' }} {!! $field['min_value'] ? 'min="' . $field['min_value'] . '"' : '' !!} {!! $field['max_value'] ? 'max="' . $field['max_value'] . '"' : '' !!} {!! $field['step'] ? 'step="' . $field['step'] . '"' : '' !!} value="{{ $field['value'] }}">
-    @elseif ($field['value_type'] === 'date')
-        <input type="{{ $field['value_type'] }}" id="{{ $module_id }}-input-{{ $field['name'] }}" class="large-text" name="mod-form[{{ $field['name'] }}]" {{  $field['required'] ? 'required' : '' }} {!! $field['min_value'] ? 'min="' . $field['min_value'] . '"' : '' !!} {!! $field['max_value'] ? 'max="' . $field['max_value'] . '"' : '' !!} value="{{ $field['value'] }}">
-    @else
-        <input type="{{ $field['value_type'] }}" id="{{ $module_id }}-input-{{ $field['name'] }}" class="large-text" name="mod-form[{{ $field['name'] }}]" {{ $field['required'] ? 'required' : '' }} value="{{ $field['value'] }}">
-    @endif
+    <p>
+        <b>
+            <label for="{{ $module_id }}-input-{{ $field['name'] }}">
+                {{ $field['label'] }}
+                @if ($field['required'])
+                    <span class="text-danger">*</span>
+                @endif
+            </label>
+        </b>
+    </p>
+
+    <input
+        type="{{ $field['value_type'] }}"
+        id="{{ $module_id }}-input-{{ $field['name'] }}"
+        class="large-text"
+        name="mod-form[{{ $field['name'] }}]"
+        value="{{ $field['value'] }}"
+        @if ($field['required'])
+            required="required"
+        @endif
+        @if (in_array($field['value_type'], array('date', 'number', 'range')))
+            min="{{ trim($field['min_value']) }}"
+            max="{{ trim($field['max_value']) }}"
+        @endif
+        @if (in_array($field['value_type'], array('number', 'range')))
+            step="{{ trim($field['step']) }}"
+        @endif
+    >
 </div>

--- a/source/php/Module/views/fields/input.blade.php
+++ b/source/php/Module/views/fields/input.blade.php
@@ -1,21 +1,44 @@
+<?php
+
+use ModularityFormBuilder\Helper\SanitizeData;
+
+?>
+
 <div class="grid mod-form-field" {!! $field['conditional_hidden'] !!}>
     <div class="grid-md-12">
         <div class="form-group">
-            <label for="{{ $module_id }}-input-{{ sanitize_title($field['label']) }}">{{ $field['label'] }}{!!  $field['required'] ? '<span class="text-danger">*</span>' : '' !!}</label>
-            {!! !empty($field['description']) ? '<div class="text-sm text-dark-gray">' . ModularityFormBuilder\Helper\SanitizeData::convertLinks($field['description']) . '</div>' : '' !!}
+            <label for="{{ $module_id }}-input-{{ sanitize_title($field['label']) }}">
+                {{ $field['label'] }}
+                @if ($field['required'])
+                    <span class="text-danger">*</span>
+                @endif
+            </label>
 
-            @if (in_array($field['value_type'], array('number', 'range')))
-                <input type="{{ $field['value_type'] }}" id="{{ $module_id }}-input-{{ sanitize_title($field['label']) }}" name="{{ sanitize_title($field['label']) }}" {{  $field['required'] ? 'required' : '' }} {!! $field['min_value'] ? 'min="' . $field['min_value'] . '"' : '' !!} {!! $field['max_value'] ? 'max="' . $field['max_value'] . '"' : '' !!} {!! $field['step'] ? 'step="' . $field['step'] . '"' : '' !!}>
-            @elseif ($field['value_type'] === 'date')
-                <input type="{{ $field['value_type'] }}" id="{{ $module_id }}-input-{{ sanitize_title($field['label']) }}" name="{{ sanitize_title($field['label']) }}" {{  $field['required'] ? 'required' : '' }} {!! $field['min_value'] ? 'min="' . $field['min_value'] . '"' : '' !!} {!! $field['max_value'] ? 'max="' . $field['max_value'] . '"' : '' !!}>
-            @else
-                <input type="{{ $field['value_type'] }}" id="{{ $module_id }}-input-{{ sanitize_title($field['label']) }}" name="{{ sanitize_title($field['label']) }}" {{  $field['required'] ? 'required' : '' }}>
+            @if (!empty($field['description']))
+                <div class="text-sm text-dark-gray">
+                    {!! SanitizeData::convertLinks($field['description']) !!}
+                </div>
             @endif
+
+            <input
+                type="{{ $field['value_type'] }}"
+                id="{{ $module_id }}-input-{{ sanitize_title($field['label']) }}"
+                name="{{ sanitize_title($field['label']) }}"
+                @if ($field['required'])
+                    required="required"
+                @endif
+                @if (in_array($field['value_type'], array('date', 'number', 'range')))
+                    min="{{ trim($field['min_value']) }}"
+                    max="{{ trim($field['max_value']) }}"
+                @endif
+                @if (in_array($field['value_type'], array('number', 'range')))
+                    step="{{ trim($field['step']) }}"
+                @endif
+            >
 
             @if (isset($field['custom_post_type_title']) && $field['custom_post_type_title'] == true)
                 <input type="hidden" name="post_title" value="{{ sanitize_title($field['label']) }}">
             @endif
-
         </div>
     </div>
 </div>


### PR DESCRIPTION
Improves the readability of the input templates.

* Shorten maximum line length from `416` to `101`.
* Remove code duplication by moving the conditions into the input tag.
* Replace `{!! unescaped !!}` templates by `{{ escaped }}` ones where possible.
  * Makes it less likely someone accidentally breaks the page with a bad character.
  * Makes it less likely someone sneaks in something malicious.

*This is mostly opinion-based*. Feel free to make suggestions!