### PR TITLE
Fix ranges in date fields

### DIFF
--- a/source/php/Helper/SanitizeData.php
+++ b/source/php/Helper/SanitizeData.php
@@ -4,21 +4,23 @@ namespace ModularityFormBuilder\Helper;
 
 class SanitizeData
 {
-	/**
-	 * Convert urls to hyperlinks
-	 * @param  string $text String to be modified
-	 * @return string 		Modified string
-	 */
-	public static function convertLinks($text) : string
-	{
-		$pattern = "/(http|https|ftp|ftps)\:\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(\/\S*)?/";
+    /**
+     * Convert urls to hyperlinks
+     *
+     * @param string $text String to be modified
+     *
+     * @return string Modified string
+     */
+    public static function convertLinks($text) : string
+    {
+        $pattern = "/(http|https|ftp|ftps)\:\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(\/\S*)?/";
 
-		// Check if there is urls in the text
-		if (preg_match($pattern, $text, $url)) {
-			// Make the urls hyper links
-		 	$text = preg_replace($pattern, "<a href='{$url[0]}'>{$url[0]}</a> ", $text);
-		}
+        // Check if there is urls in the text
+        if (preg_match($pattern, $text, $url)) {
+            // Make the urls hyper links
+            $text = preg_replace($pattern, "<a href='{$url[0]}'>{$url[0]}</a> ", $text);
+        }
 
-		return $text;
-	}
+        return $text;
+    }
 }

--- a/source/php/Helper/SanitizeData.php
+++ b/source/php/Helper/SanitizeData.php
@@ -23,4 +23,22 @@ class SanitizeData
 
         return $text;
     }
+
+    /**
+     * Formats a date for an input field.
+     *
+     * @param string $text Textual representation of the date.
+     *
+     * @return string A formatted version of the date.
+     */
+    public static function formatDate($text) : string
+    {
+        $parsed = strtotime($text);
+
+        if ($parsed === false) {
+            return '';
+        }
+
+        return date('Y-m-d', $parsed);
+    }
 }

--- a/source/php/Module/views/fields-editable/input.blade.php
+++ b/source/php/Module/views/fields-editable/input.blade.php
@@ -1,3 +1,9 @@
+<?php
+
+use ModularityFormBuilder\Helper\SanitizeData;
+
+?>
+
 <div class="mod-form-field">
     <p>
         <b>
@@ -19,11 +25,12 @@
         @if ($field['required'])
             required="required"
         @endif
-        @if (in_array($field['value_type'], array('date', 'number', 'range')))
+        @if ($field['value_type'] == 'date')
+            min="{{ SanitizeData::formatDate($field['min_value']) }}"
+            max="{{ SanitizeData::formatDate($field['max_value']) }}"
+        @elseif (in_array($field['value_type'], array('number', 'range')))
             min="{{ trim($field['min_value']) }}"
             max="{{ trim($field['max_value']) }}"
-        @endif
-        @if (in_array($field['value_type'], array('number', 'range')))
             step="{{ trim($field['step']) }}"
         @endif
     >

--- a/source/php/Module/views/fields/input.blade.php
+++ b/source/php/Module/views/fields/input.blade.php
@@ -27,11 +27,12 @@ use ModularityFormBuilder\Helper\SanitizeData;
                 @if ($field['required'])
                     required="required"
                 @endif
-                @if (in_array($field['value_type'], array('date', 'number', 'range')))
+                @if ($field['value_type'] == 'date')
+                    min="{{ SanitizeData::formatDate($field['min_value']) }}"
+                    max="{{ SanitizeData::formatDate($field['max_value']) }}"
+                @elseif (in_array($field['value_type'], array('number', 'range')))
                     min="{{ trim($field['min_value']) }}"
                     max="{{ trim($field['max_value']) }}"
-                @endif
-                @if (in_array($field['value_type'], array('number', 'range')))
                     step="{{ trim($field['step']) }}"
                 @endif
             >


### PR DESCRIPTION
Validation appears to break when creating a required date field with a valid range.

This change ensures that the date (if any) is formatted according to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).