### PR TITLE
Fix empty sender values

### DIFF
--- a/source/php/PostType.php
+++ b/source/php/PostType.php
@@ -310,7 +310,7 @@ class PostType
                         'name' => sanitize_title($field['labels'][$subfield]),
                         'required' => (is_array($field['required_fields']) && in_array($subfield,
                                 $field['required_fields'])),
-                        'value' => (!empty($indata[sanitize_title($field['labels'][$subfield])])) ? $indata[sanitize_title($field['labels'][$subfield])] : '',
+                        'value' => (!empty($indata[$subfield])) ? $indata[$subfield] : '',
                     );
                 }
 


### PR DESCRIPTION
Populate sender field from indata fields that matches the correct subfield keys.

This will populate fields such as "Firstname", "Lastname", "Email" in the wp-admin view for Submitted form data.

Form "submission data" before fix
![screen shot 2018-08-21 at 16 09 04](https://user-images.githubusercontent.com/13356945/44406756-b3fbd480-a55c-11e8-9b83-57ab94882933.png)

Forms with PR applied
![screen shot 2018-08-21 at 16 07 56](https://user-images.githubusercontent.com/13356945/44406905-10f78a80-a55d-11e8-8c17-74b257fd7cdd.png)


