### PR TITLE
Conditional JSON would break the HTML attributes. By replaceing doubl…

### DIFF
--- a/source/js/front/handle-conditions.js
+++ b/source/js/front/handle-conditions.js
@@ -15,7 +15,9 @@ export default (function ($) {
             const target = $(e.target).parents('[class*="mod-form"]');
             var conditional = $(e.target).attr('conditional');
             if (typeof conditional !== 'undefined' && conditional.length > 0) {
+                conditional = conditional.replaceAll("'", '"'); //HTML attribute breaks when using double quotes, therefore single quotes are used
                 var conditionObj = JSON.parse(conditional);
+
                 target.find("div[conditional-target^='{\"label\":\"" + conditionObj.label + "\",']").hide();
                 target.find("div[conditional-target='" + conditional + "']").show();
             }

--- a/source/php/Module/Form.php
+++ b/source/php/Module/Form.php
@@ -218,7 +218,9 @@ class Form extends \Modularity\Module
                         'label' => $label,
                         'value' => $option_value
                     );
-                    $value['conditional_value'] = json_encode($conditional_value);
+
+                    //HTML attribute breaks when using double quotes, therefore single quotes are used
+                    $value['conditional_value'] = str_replace('"', "'", json_encode($conditional_value));
                 }
             }
 


### PR DESCRIPTION
…e quotes with single quotes the attribte stays intact but breaks the JSON data, therefore we replace the single quotes with double quotes before parsing the JSON.